### PR TITLE
Use os.sep as a first step - ideally os.path.split should be used but…

### DIFF
--- a/api.py
+++ b/api.py
@@ -122,7 +122,7 @@ def getAllModsData(modIDs):
             #modData.url = requests.head(modData.downloadLink, allow_redirects=True).url #resolve to final download URL
             #modData.filename = modData.url.split("/")[-1]
             modData.filename = modfileData["filename"]
-            modData.modFolder = "{}\\UGC{}".format(modPath, modData.id)
+            modData.modFolder = os.path.join(modPath, "UGC"+str(modData.id))
             
             modList.append(modData)
         

--- a/api.py
+++ b/api.py
@@ -122,7 +122,7 @@ def getAllModsData(modIDs):
             #modData.url = requests.head(modData.downloadLink, allow_redirects=True).url #resolve to final download URL
             #modData.filename = modData.url.split("/")[-1]
             modData.filename = modfileData["filename"]
-            modData.modFolder = os.path.join(modPath, "UGC"+str(modData.id))
+            modData.modFolder = os.path.join(modPath, "UGC" + str(modData.id))
             
             modList.append(modData)
         

--- a/downloads.py
+++ b/downloads.py
@@ -54,7 +54,7 @@ def downloadFile(url, dir):
     
     #Get the filename from URL, strip off parameters
     filename = url.split("/")[-1].split("?")[0].split("#")[0]
-    filePath = dir + "\\" + filename
+    filePath = os.path.join(dir, filename)
     
     #don't redownload if file already exists; if it's incomplete/invalid the hash check will catch it
     if os.path.exists(filePath):
@@ -122,7 +122,7 @@ def downloadMod(mod):
         print(f"Size: {mod.downloadSize} (expected), {os.path.getsize(zipPath)} (actual)")
         stop()
     
-    dataPath = mod.modFolder + "\\Data"
+    dataPath = os.path.join(mod.modFolder, "Data")
     
     #clean old files to make sure we don't end up with leftovers
     if os.path.exists(mod.modFolder):
@@ -137,7 +137,7 @@ def downloadMod(mod):
             return False
             
     os.remove(zipPath)
-    with open(mod.modFolder + "\\taint", "w") as taint:
+    with open(os.path.join(mod.modFolder, "taint"), "w") as taint:
         taint.write(str(mod.modfile_live))
     
     return True

--- a/update.py
+++ b/update.py
@@ -96,7 +96,7 @@ def queueOnDiskUpdates():
     
     modIDs = []
     modVersions = []
-    for folder in [f[0] for f in os.walk(modPath) if os.path.isdir(f[0]) and f[0].split("\\")[-1].startswith("UGC")]:
+    for folder in [f[0] for f in os.walk(modPath) if os.path.isdir(f[0]) and f[0].split(os.sep)[-1].startswith("UGC")]:
         modID = folder.split("UGC")[-1]
         
         if not modID.isdigit(): #skip folders that don't follow the valid mod folder name format
@@ -105,7 +105,7 @@ def queueOnDiskUpdates():
         #mod = api.getModData(modID)
         
         try:
-            with open(folder + "\\taint", "r") as taint:
+            with open(os.path.join(folder, "taint"), "r") as taint:
                 installed = int(taint.read())
         except Exception as e:
             print(f"Unable to identify installed version of {modID} via taint file; mod will be treated as needing an update.")


### PR DESCRIPTION
Couple of changes to make this mod manager work under Linux and Windows. I only altered what was absolutely neccessary to keep the diff small.