### PR TITLE
Use OS-agnostic path separators/logic

### DIFF
--- a/SETTINGS.json
+++ b/SETTINGS.json
@@ -2,8 +2,5 @@
     "mods_path": "%localappdata%\\Pavlov\\Saved\\Mods",
     "game_platform": "windows",
     "download_threads": 10,
-    "ignore_mods": [
-        3051820,
-        3051820
-    ]
+    "ignore_mods": []
 }

--- a/api.py
+++ b/api.py
@@ -122,7 +122,7 @@ def getAllModsData(modIDs):
             #modData.url = requests.head(modData.downloadLink, allow_redirects=True).url #resolve to final download URL
             #modData.filename = modData.url.split("/")[-1]
             modData.filename = modfileData["filename"]
-            modData.modFolder = os.path.join(modPath, "UGC" + str(modData.id))
+            modData.modFolder = os.path.join(modPath, f"UGC{modData.id}")
             
             modList.append(modData)
         

--- a/api.py
+++ b/api.py
@@ -122,7 +122,7 @@ def getAllModsData(modIDs):
             #modData.url = requests.head(modData.downloadLink, allow_redirects=True).url #resolve to final download URL
             #modData.filename = modData.url.split("/")[-1]
             modData.filename = modfileData["filename"]
-            modData.modFolder = "{}\\UGC{}".format(modPath, modData.id)
+            modData.modFolder = os.path.join(modPath, "UGC"+str(modData.id))
             
             modList.append(modData)
         

--- a/api.py
+++ b/api.py
@@ -122,7 +122,7 @@ def getAllModsData(modIDs):
             #modData.url = requests.head(modData.downloadLink, allow_redirects=True).url #resolve to final download URL
             #modData.filename = modData.url.split("/")[-1]
             modData.filename = modfileData["filename"]
-            modData.modFolder = os.path.join(modPath, "UGC"+str(modData.id))
+            modData.modFolder = os.path.join(modPath, "UGC" + str(modData.id))
             
             modList.append(modData)
         

--- a/config.py
+++ b/config.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import json
+from sys import exit #otherwise PyInstaller complains
 
 #Just prompts for input before calling exit() so you can read the error message before the window closes
 def stop(exitCode = 0):

--- a/downloads.py
+++ b/downloads.py
@@ -6,6 +6,7 @@ import requests
 from urllib.request import urlopen, Request
 from zipfile import ZipFile, BadZipFile
 import time
+import os
 
 #local files
 from config import *
@@ -101,7 +102,7 @@ def downloadFile(url, dir):
     print("Download complete, installing...")
     return filePath
 
-def downloadMod(mod):
+def downloadMod(mod, test=False):
     #print(mod.md5)
     #exit()
     if int(mod.id) in IGNORE:
@@ -123,6 +124,11 @@ def downloadMod(mod):
         stop()
     
     dataPath = os.path.join(mod.modFolder, "Data")
+    
+    if test:
+        print(f"TEST flag set, skipping installation")
+        os.remove(zipPath)
+        return True
     
     #clean old files to make sure we don't end up with leftovers
     if os.path.exists(mod.modFolder):

--- a/downloads.py
+++ b/downloads.py
@@ -54,7 +54,7 @@ def downloadFile(url, dir):
     
     #Get the filename from URL, strip off parameters
     filename = url.split("/")[-1].split("?")[0].split("#")[0]
-    filePath = dir + "\\" + filename
+    filePath = os.path.join(dir, filename)
     
     #don't redownload if file already exists; if it's incomplete/invalid the hash check will catch it
     if os.path.exists(filePath):
@@ -122,7 +122,7 @@ def downloadMod(mod):
         print(f"Size: {mod.downloadSize} (expected), {os.path.getsize(zipPath)} (actual)")
         stop()
     
-    dataPath = mod.modFolder + "\\Data"
+    dataPath = os.path.join(mod.modFolder, "Data")
     
     #clean old files to make sure we don't end up with leftovers
     if os.path.exists(mod.modFolder):
@@ -137,7 +137,7 @@ def downloadMod(mod):
             return False
             
     os.remove(zipPath)
-    with open(mod.modFolder + "\\taint", "w") as taint:
+    with open(os.path.join(mod.modFolder, "taint"), "w") as taint:
         taint.write(str(mod.modfile_live))
     
     return True

--- a/update.py
+++ b/update.py
@@ -96,7 +96,7 @@ def queueOnDiskUpdates():
     
     modIDs = []
     modVersions = []
-    for folder in [f[0] for f in os.walk(modPath) if os.path.isdir(f[0]) and f[0].split("\\")[-1].startswith("UGC")]:
+    for folder in [f[0] for f in os.walk(modPath) if os.path.isdir(f[0]) and f[0].split(os.sep)[-1].startswith("UGC")]:
         modID = folder.split("UGC")[-1]
         
         if not modID.isdigit(): #skip folders that don't follow the valid mod folder name format
@@ -105,7 +105,7 @@ def queueOnDiskUpdates():
         #mod = api.getModData(modID)
         
         try:
-            with open(folder + "\\taint", "r") as taint:
+            with open(os.path.join(folder, "taint"), "r") as taint:
                 installed = int(taint.read())
         except Exception as e:
             print(f"Unable to identify installed version of {modID} via taint file; mod will be treated as needing an update.")


### PR DESCRIPTION
Path handlers are now OS-agnostic with regard to path separators, so this might now work on Linux. 
- The `mods_path` value in SETTINGS.json probably still needs to be OS-specific. 

Fixed a crash that would occur every time the compiled binary file exited. 

Removed mod IDs from the ignore list that were only supposed to be there for testing. 